### PR TITLE
Add note about URL base to both Sonarr and Radarr. 

### DIFF
--- a/Radarr-Attributes.md
+++ b/Radarr-Attributes.md
@@ -22,7 +22,7 @@ radarr:
 
 | Name | Attribute | Allowed Values| Default | Required |
 | :--- | :--- | :--- | :---: | :---: |
-| Radarr URL | `url` | Radarr URL<br>**Example:** http://192.168.1.12:32788 | N/A | :heavy_check_mark: |
+| Radarr URL | `url` | Radarr URL (Including URL Base if set)<br>**Example:** http://192.168.1.12:32788 | N/A | :heavy_check_mark: |
 | API Token | `token` | Radarr API Token | N/A | :heavy_check_mark: |
 | Add | `add` | Add missing movies found to Radarr<br>**boolean:** true or false | false | :x: |
 | Add Existing | `add_existing` | Add movie existing in this collection to Radarr<br>**boolean:** true or false | false | :x: |

--- a/Sonarr-Attributes.md
+++ b/Sonarr-Attributes.md
@@ -25,7 +25,7 @@ sonarr:
 
 | Name | Attribute | Allowed Values| Default | Required |
 | :--- | :--- | :--- | :---: | :---: |
-| Sonarr URL | `url` | Sonarr URL<br>**Example:** http://192.168.1.12:32788 | N/A | :heavy_check_mark: |
+| Sonarr URL | `url` | Sonarr URL (Including URL Base if set)<br>**Example:** http://192.168.1.12:32788 | N/A | :heavy_check_mark: |
 | API Token | `token` | Sonarr API Token | N/A | :heavy_check_mark: |
 | Add | `add` | Add missing shows found to Sonarr<br>**boolean:** true or false | false | :x: |
 | Add Existing | `add_existing` | Add shows existing in this collection to Sonarr<br>**boolean:** true or false | false | :x: |


### PR DESCRIPTION
This prevents the confusing error when adding new movies : "Radarr Error: (404 [Not Found]) Item Not Found {'message': 'NotFound'}"